### PR TITLE
Fix apostrophe characters in WindowManager comments

### DIFF
--- a/project-root/WindowManager.js
+++ b/project-root/WindowManager.js
@@ -6,7 +6,7 @@ class WindowManager {
       this.channel = new BroadcastChannel(channelName);
       this.peers = new Map();                         // Map<peerId, { x, y, lastSeen }>
   
-      // Start broadcasting our window’s position
+      // Start broadcasting our window's position
       this._startBroadcast();
   
       // Listen for incoming messages from other windows
@@ -38,7 +38,7 @@ class WindowManager {
     }
   
     /**
-     * Returns an array of other windows’ positions:
+     * Returns an array of other windows' positions:
      * [ { id, x, y }, ... ]
      */
     getPeers() {


### PR DESCRIPTION
## Summary
- fix typography in WindowManager comments to use standard apostrophes

## Testing
- `grep -n "’" project-root/WindowManager.js`

------
https://chatgpt.com/codex/tasks/task_e_684e25735d708333b84b3c18b51bd89c